### PR TITLE
Fixes #19 – Fix malformed OCSP request

### DIFF
--- a/src/OcspRequest.php
+++ b/src/OcspRequest.php
@@ -32,7 +32,7 @@ use web_eid\ocsp_php\util\AsnUtil;
 
 class OcspRequest
 {
-    private array $ocspRequest = [];
+    private array $ocspRequest;
 
     public function __construct()
     {
@@ -41,8 +41,6 @@ class OcspRequest
         $this->ocspRequest = [
             "tbsRequest" => [
                 "version" => "v1",
-                "requestList" => [],
-                "requestExtensions" => [],
             ],
         ];
     }
@@ -62,9 +60,7 @@ class OcspRequest
             "critical" => false,
             "extnValue" => ASN1::encodeDER($nonce, ['type' => ASN1::TYPE_OCTET_STRING]),
         ];
-        $this->ocspRequest["tbsRequest"][
-            "requestExtensions"
-        ][] = $nonceExtension;
+        $this->ocspRequest["tbsRequest"]["requestExtensions"][] = $nonceExtension;
     }
 
     /**
@@ -73,7 +69,7 @@ class OcspRequest
     public function getNonceExtension(): string
     {
         // TODO: the ?? '' is here only for v1.0 API compatibility. Remove this in version 1.2 and change the return type to ?string.
-        return AsnUtil::decodeNonceExtension($this->ocspRequest["tbsRequest"]["requestExtensions"]) ?? '';
+        return AsnUtil::decodeNonceExtension($this->ocspRequest["tbsRequest"]["requestExtensions"] ?? []) ?? '';
     }
 
     public function getEncodeDer(): string

--- a/tests/OcspRequestTest.php
+++ b/tests/OcspRequestTest.php
@@ -39,8 +39,6 @@ class OcspRequestTest extends TestCase
         return [
             'tbsRequest' => [
                 'version' => 'v1',
-                'requestList' => [],
-                'requestExtensions' => [],
             ],
         ];
     }


### PR DESCRIPTION
- Remove empty arrays from request
- Array will be created when value is added to it
- Always having an empty array leads to additional nodes in request that are considered malformed

Signed-off-by: Kai Hölscher <51371415+hoels@users.noreply.github.com>
