### PR TITLE
Add support for SHA256

### DIFF
--- a/src/util/AsnUtil.php
+++ b/src/util/AsnUtil.php
@@ -38,6 +38,7 @@ class AsnUtil
         ASN1::loadOIDs([
             "id-pkix-ocsp-nonce" => self::ID_PKIX_OCSP_NONCE,
             "id-sha1" => "1.3.14.3.2.26",
+            "id-sha256" => "2.16.840.1.101.3.4.2.1",
             "sha256WithRSAEncryption" => "1.2.840.113549.1.1.11",
             "qcStatements(3)" => "1.3.6.1.5.5.7.1.3",
             "street" => "2.5.4.9",

--- a/src/util/HashAlgorithm.php
+++ b/src/util/HashAlgorithm.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace web_eid\ocsp_php\util;
+
+enum HashAlgorithm: string
+{
+    case SHA1 = "sha1";
+    case SHA256 = "sha256";
+}


### PR DESCRIPTION
Right now, SHA1 is used for hashing the issuer name and key. SHA1 is not only considered insecure, its support is increasingly dropped by OCSP responders. For example, [Microsoft dropped SHA1 support](https://learn.microsoft.com/en-us/azure/security/fundamentals/ocsp-sha-1-sunset) 2 years ago.

It would be nice to have the option of using different hash algorithms. In this pull request, I added the possibility to use SHA256 while keeping SHA1 as the default option. With this structure, you could also add support for additional algorithms.

I kept SHA1 as the default to prevent breaks. However, I would recommend switching to SHA256 in a future version for increased security.

Signed-off-by: Kai Hölscher 51371415+hoels@users.noreply.github.com
